### PR TITLE
Enforce 80 token limit for free model with usage tracking

### DIFF
--- a/src/lib/ai-client.ts
+++ b/src/lib/ai-client.ts
@@ -708,6 +708,17 @@ Remember: You are ${character.name}, a passionate, willing, and sexually liberat
       })
     });
 
+    // Record usage/meta for verification
+    this.lastCallMeta = {
+      model: this.model,
+      requested_max_tokens: dynamicMaxTokens,
+      applied_max_tokens: computedMaxTokens,
+      usage: completion.usage,
+      timestamp: new Date().toISOString(),
+    };
+    try { localStorage.setItem('ai_last_call_meta', JSON.stringify(this.lastCallMeta)); } catch {}
+    console.log('[AI] Call meta', this.lastCallMeta);
+
     const response = completion.choices[0]?.message?.content;
 
     if (!response) {

--- a/src/lib/ai-client.ts
+++ b/src/lib/ai-client.ts
@@ -590,6 +590,10 @@ Remember: You are ${character.name}, a passionate, willing, and sexually liberat
     return this.connectionStatus;
   }
 
+  getLastCallMeta() {
+    return this.lastCallMeta;
+  }
+
   private getCommandDirectives(): { text: string; reduceRepetition: boolean; targetWords?: number } {
     try {
       const serverRaw = localStorage.getItem('command_instructions_server');

--- a/src/lib/ai-client.ts
+++ b/src/lib/ai-client.ts
@@ -662,8 +662,8 @@ Remember: You are ${character.name}, a passionate, willing, and sexually liberat
     })();
 
     // Enforce strict cap for free-tier models selected via ModelsModal
-    const isFreeModel = /:free\b/i.test(this.model);
-    const computedMaxTokens = isFreeModel ? Math.min(dynamicMaxTokens, 80) : dynamicMaxTokens;
+    const isPrimaryFreeModel = this.model === 'mistralai/mistral-nemo:free';
+    const computedMaxTokens = isPrimaryFreeModel ? 80 : dynamicMaxTokens;
 
     // Debug: Log token allocation for word count commands
     if (directives.targetWords) {

--- a/src/lib/ai-client.ts
+++ b/src/lib/ai-client.ts
@@ -12,6 +12,13 @@ class AIClient {
   private provider: 'openrouter' = 'openrouter';
   private isInitialized: boolean = false;
   private connectionStatus: 'initializing' | 'connected' | 'failed' = 'initializing';
+  private lastCallMeta?: {
+    model: string;
+    requested_max_tokens: number;
+    applied_max_tokens: number;
+    usage?: { prompt_tokens?: number; completion_tokens?: number; total_tokens?: number };
+    timestamp: string;
+  };
 
   // Simple actions that should be forbidden or enhanced
   private forbiddenSimpleActions = [

--- a/src/lib/ai-client.ts
+++ b/src/lib/ai-client.ts
@@ -661,9 +661,13 @@ Remember: You are ${character.name}, a passionate, willing, and sexually liberat
       return 3000;
     })();
 
+    // Enforce strict cap for free-tier models selected via ModelsModal
+    const isFreeModel = /:free\b/i.test(this.model);
+    const computedMaxTokens = isFreeModel ? Math.min(dynamicMaxTokens, 80) : dynamicMaxTokens;
+
     // Debug: Log token allocation for word count commands
     if (directives.targetWords) {
-      console.log(`🎯 Word count directive: ${directives.targetWords} words → ${dynamicMaxTokens} max tokens`);
+      console.log(`🎯 Word count directive: ${directives.targetWords} words → ${dynamicMaxTokens} max tokens (applied: ${computedMaxTokens})`);
     }
 
     // Optimized parameters with directive-aware tuning
@@ -671,7 +675,7 @@ Remember: You are ${character.name}, a passionate, willing, and sexually liberat
       model: this.model,
       messages,
       temperature: 0.8,
-      max_tokens: dynamicMaxTokens,
+      max_tokens: computedMaxTokens,
       top_p: 0.9,
       frequency_penalty: directives.reduceRepetition ? 0.6 : 0.2,
       presence_penalty: 0.4,
@@ -685,7 +689,7 @@ Remember: You are ${character.name}, a passionate, willing, and sexually liberat
       }),
       ...(this.model.includes('dolphin') && {
         temperature: 0.9,
-        max_tokens: Math.min(dynamicMaxTokens, 2500)
+        max_tokens: Math.min(computedMaxTokens, 2500)
       }),
       ...(this.model.includes('deepseek') && {
         temperature: 0.75,


### PR DESCRIPTION
## Purpose

The user requested to enforce a strict 80 token limit for the free model (`mistralai/mistral-nemo:free`) accessible through the models modal. They emphasized that this limit must never be exceeded, regardless of other configurations, and wanted the ability to analyze and verify that responses truly use only 80 tokens.

## Code changes

- **Token limit enforcement**: Added strict 80 token cap for `mistralai/mistral-nemo:free` model, overriding dynamic token calculations
- **Usage tracking**: Implemented `lastCallMeta` property to store detailed call metadata including:
  - Model used
  - Requested vs applied max tokens
  - Token usage statistics
  - Timestamp
- **Verification support**: Added `getLastCallMeta()` method and localStorage persistence for call metadata
- **Enhanced logging**: Updated debug logs to show both calculated and applied token limits
- **Model-specific handling**: Applied token cap logic to all model-specific parameter configurationsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 135`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5ca7f8c4bf2a4281b108e059f742e323/echo-world)

👀 [Preview Link](https://5ca7f8c4bf2a4281b108e059f742e323-echo-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5ca7f8c4bf2a4281b108e059f742e323</projectId>-->
<!--<branchName>echo-world</branchName>-->